### PR TITLE
fix readme instructions for terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Requires a [Go installation](https://go.dev/dl/) to run the examples.
 
 2. Navigate to example's directory
     ```sh
-    cd gopherlings/exercise/001-hello
+    cd gopherlings/exercises/001-hello
     ```
 
 3. Edit the file so it is correct and run it with `go run`


### PR DESCRIPTION
change `exercise` to `exercises` in the terminal instructions to properly reflect the path to the exercise